### PR TITLE
build(deps-dev): bump rack from 3.2.1 to 3.2.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shc (0.0.2)
+    shc (0.0.3)
       multi_json (~> 1.17)
 
 GEM
@@ -47,7 +47,7 @@ GEM
     highline (2.1.0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    json (2.13.2)
+    json (2.15.1)
     json_pure (2.6.3)
     language_server-protocol (3.17.0.5)
     launchy (2.5.2)
@@ -72,13 +72,13 @@ GEM
       json
       websocket (~> 1.0)
     racc (1.8.1)
-    rack (3.2.1)
+    rack (3.2.2)
     rack-test (2.1.0)
       rack (>= 1.3)
     rainbow (3.1.1)
     rake (13.3.0)
     regexp_parser (2.11.3)
-    rubocop (1.80.2)
+    rubocop (1.81.1)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -86,10 +86,10 @@ GEM
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.46.0, < 2.0)
+      rubocop-ast (>= 1.47.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.46.0)
+    rubocop-ast (1.47.1)
       parser (>= 3.3.7.2)
       prism (~> 1.4)
     ruby-progressbar (1.13.0)

--- a/lib/shc/version.rb
+++ b/lib/shc/version.rb
@@ -1,3 +1,3 @@
 module SHC
-  VERSION = '0.0.2'.freeze
+  VERSION = '0.0.3'.freeze
 end


### PR DESCRIPTION
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/rack/rack/blob/main/CHANGELOG.md">rack's changelog</a>.</em></p>
<blockquote>
<h2>[3.2.2] - 2025-10-07</h2>
<h3>Security</h3>
<ul>
<li><a href="https://github.com/advisories/GHSA-wpv5-97wm-hp9c">CVE-2025-61772</a> Multipart parser buffers unbounded per-part headers, enabling DoS (memory exhaustion)</li>
<li><a href="https://github.com/advisories/GHSA-w9pc-fmgc-vxvw">CVE-2025-61771</a> Multipart parser buffers large non‑file fields entirely in memory, enabling DoS (memory exhaustion)</li>
<li><a href="https://github.com/advisories/GHSA-p543-xpfm-54cp">CVE-2025-61770</a> Unbounded multipart preamble buffering enables DoS (memory exhaustion)</li>
</ul>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/rack/rack/commit/bce149b11154e851c437b5ece1c026c943f4b571"><code>bce149b</code></a> Bump patch version.</li>
<li><a href="https://github.com/rack/rack/commit/3beacfcd494ec5600c9022d561cfa2f556a524d1"><code>3beacfc</code></a> Limit amount of retained data when parsing multipart requests</li>
<li><a href="https://github.com/rack/rack/commit/589127f4ac8b5cf11cf88fb0cd116ffed4d2181e"><code>589127f</code></a> Fix denial of service vulnerbilties in multipart parsing</li>
<li>See full diff in <a href="https://github.com/rack/rack/compare/v3.2.1...v3.2.2">compare view</a></li>
</ul>
</details>